### PR TITLE
Fix night sync.

### DIFF
--- a/src/store/index.js
+++ b/src/store/index.js
@@ -165,13 +165,20 @@ export default new Vuex.Store({
     toggleMenu: toggle("isMenuOpen"),
     toggleNightOrder: toggle("isNightOrder"),
     toggleStatic: toggle("isStatic"),
-    toggleNight({ grimoire, players }) {
+    toggleNight({ grimoire, players }, val) {
       // Reset the hasResponded var for the next night.
       players.players.map((player) => {
         player.hasResponded = {};
       })
 
-      grimoire.isNight = !grimoire.isNight;
+      // This function can be called with an explicit value pushed from the
+      // socket. In that case, the value the host has declared takes effect,
+      // assuming it is at least a valid boolean.
+      if (val === true || val === false) {
+        grimoire.isNight = val;
+      } else {
+        grimoire.isNight = !grimoire.isNight;
+      }
     },
     toggleGrimoire: toggle("isPublic"),
     toggleImageOptIn: toggle("isImageOptIn"),


### PR DESCRIPTION
toggleNight is used not only by the user to switch between day and night, but also by the socket handling code to push values from the host to the clients. In that case, the client must accept the value the host has declared.

This mirrors the behavior of the pre-existing `toggle`, which was replaced in 66a36d74225d164657da2fa94861ee0feea8112d.

h/t to @WedgeMcCloud for identifying the culprit commit.