### PR TITLE
Implement simple client authentication for receiving direct messages and make it harder to claim occupied seats

### DIFF
--- a/src/store/modules/session.js
+++ b/src/store/modules/session.js
@@ -46,6 +46,7 @@ const set = (key) => (state, val) => {
 
 const mutations = {
   setPlayerId: set("playerId"),
+  setPlayerSecret: set("playerSecret"),
   setSpectator: set("isSpectator"),
   setReconnecting: set("isReconnecting"),
   setPlayerCount: set("playerCount"),

--- a/src/store/persistence.js
+++ b/src/store/persistence.js
@@ -63,6 +63,9 @@ module.exports = (store) => {
   if (localStorage.getItem("playerId")) {
     store.commit("session/setPlayerId", localStorage.getItem("playerId"));
   }
+  if (localStorage.getItem("playerSecret")) {
+    store.commit("session/setPlayerSecret", localStorage.getItem("playerSecret"));
+  }
   if (localStorage.getItem("session") && !window.location.hash.substr(1)) {
     const [spectator, sessionId] = JSON.parse(localStorage.getItem("session"));
     store.commit("session/setSpectator", spectator);
@@ -181,6 +184,13 @@ module.exports = (store) => {
           localStorage.setItem("playerId", payload);
         } else {
           localStorage.removeItem("playerId");
+        }
+        break;
+      case "session/setPlayerSecret":
+        if (payload) {
+          localStorage.setItem("playerSecret", payload);
+        } else {
+          localStorage.removeItem("playerSecret");
         }
         break;
     }

--- a/src/store/socket.js
+++ b/src/store/socket.js
@@ -707,10 +707,10 @@ class LiveSession {
         value: "",
       });
     }
-    // add playerId to new seat
+    // add playerId to new seat unless it is already occupied
     if (index >= 0) {
       const player = players[index];
-      if (!player) return;
+      if (!player || player.id) return;
       this._store.commit("players/update", { player, property, value });
     }
     // update player session list as if this was a ping

--- a/src/store/socket.js
+++ b/src/store/socket.js
@@ -28,7 +28,10 @@ class LiveSession {
       this._wss +
         channel +
         "/" +
-        (this._isSpectator ? this._store.state.session.playerId : "host"),
+        (this._isSpectator
+          ? (encodeURIComponent(this._store.state.session.playerId) + "?secret=" +
+            encodeURIComponent(this._store.state.session.playerSecret))
+          : "host")
     );
     this._socket.addEventListener("message", this._handleMessage.bind(this));
     this._socket.onopen = this._onOpen.bind(this);
@@ -221,15 +224,20 @@ class LiveSession {
 
   /**
    * Connect to a new live session, either as host or spectator.
-   * Set a unique playerId if there isn't one yet.
+   * Set a unique playerId if there isn't one yet (or the previous one is obsolete).
    * @param channel
    */
-  connect(channel) {
-    if (!this._store.state.session.playerId) {
-      this._store.commit(
-        "session/setPlayerId",
-        Math.random().toString(36).substr(2),
-      );
+  async connect(channel) {
+    function toBase64URL(u8Array) {
+      return btoa(String.fromCharCode(...u8Array)).replaceAll("+", "-").replaceAll("/", "_").replace(/=+$/, "");
+    }
+    let playerId = this._store.state.session.playerId;
+    if (!playerId || playerId.indexOf("__s_") !== 0) {
+      const playerSecret = crypto.getRandomValues(new Uint8Array(32));
+      const digestInput = new Uint8Array([155, 113, 7, 193, 229, 225, 124, 147, 153, 27, 254, 60, 164, 234, 108, 10, ...playerSecret]);
+      playerId = "__s_" + toBase64URL(new Uint8Array(await crypto.subtle.digest("SHA-256", digestInput)));
+      this._store.commit("session/setPlayerId", playerId);
+      this._store.commit("session/setPlayerSecret", toBase64URL(playerSecret));
     }
     this._pings = {};
     this._store.commit("session/setPlayerCount", 0);


### PR DESCRIPTION
The next time they connect to the socket server after refreshing with the updated client code, clients will upgrade from an old player ID to a new player ID (beginning with `__s_`). These new IDs are the SHA-256 of a random secret value (with a fixed but novel prefix to make it harder to use precomputed tables). The underlying secret is never shared with other clients, but must be passed to the server to register a connection as associated with that player ID (and thus eligible to receive messages directed at a single player). Any attempt to impersonate an upgraded client will be rejected on connection establishment. Computing the secret from the player ID would require being able to generate a SHA-256 preimage, which is currently believed to be infeasible.

Legacy clients (users who have not yet refreshed) can still connect, but won't be similarly protected right away. Similarly, new clients connecting to an old server still works, but the server won't protect them.

As a more minor point, make it harder to claim an occupied seat (the host now rejects this, in addition to the client UI doing so).