### PR TITLE
Fix Token.getImage

### DIFF
--- a/src/components/Token.vue
+++ b/src/components/Token.vue
@@ -73,7 +73,7 @@ export default {
   methods: {
     getImage(role) {
       if (role.image && this.grimoire.isImageOptIn) {
-        if (role.image?.length) {
+        if (Array.isArray(role.image)) {
           return role.image[0];
         }
 


### PR DESCRIPTION
The `length` method is also present on a String. So every custom image that was not contained in an array got returned as the first char of the link. Most of the time this will result in a `h` being returned.