### PR TITLE
Minor grammar fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+### Version 2.16.4
+- fixed minor spelling mistakes in code documentation
+- fixed Banshee votes being shown as the singular form "2 vote" during a nomination if no other players voted
+
 ### Version 2.16.3
 - adjusted the Add Fabled and Choose & Assign windows to be more mobile friendly
 

--- a/src/components/Vote.vue
+++ b/src/components/Vote.vue
@@ -12,7 +12,7 @@
       <br />
       <template v-if="!session.isSpectator || session.isVoteWatchingAllowed">
         <em class="blue">
-          {{ voteCount }} vote{{ voters.length !== 1 ? "s" : "" }}
+          {{ voteCount }} vote{{ voteCount !== 1 ? "s" : "" }}
         </em>
         in favor
       </template>

--- a/src/store/modules/players.js
+++ b/src/store/modules/players.js
@@ -106,9 +106,9 @@ const mutations = {
   },
   /**
   The update mutation also has a property for isFromSockets
-  this property can be addded to payload object for any mutations
+  this property can be added to payload object for any mutations
   then can be used to prevent infinite loops when a property is
-  able to be set from multiple different session on websockets.
+  able to be set from multiple different sessions on websockets.
   An example of this is in the sendPlayerPronouns and _updatePlayerPronouns
   in socket.js.
    */


### PR DESCRIPTION
- Fixed some minor spelling mistakes in code documentation
- Fixed Banshee votes being shown as singular if no other player voted (e.g. "2 vote")