### PR TITLE
Reserve seats for disconnected players

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,14 @@
 # Release Notes
+
+### Version 2.18.0
+- Players that lose connection to their active session have their seats reserved in case they reconnect
+- Reserved seats cannot be claimed by another player and have their chair icon display as red
+- If a player reconnects they can claim their reserved seat using the "Claim seat" button as if it were an unclaimed seat
+- The Storyteller can manually empty a reserved seat with the "Empty seat" button as if it were a claimed seat
+- Players manually vacating a seat using the "Vacate seat" or "Leave Session" buttons do not reserve the seat they vacated
+
+---
+
 ### Version 2.17.1
 - updated fabled json to include Bootlegger, Ferryman, and Gardener
 - fixed inconsistency with official app and physical game where characters with multiple of the same reminder would only show one leaf

--- a/src/components/Player.vue
+++ b/src/components/Player.vue
@@ -11,7 +11,7 @@
             session.markedPlayer === index,
           'no-vote': player.isVoteless,
           'two-votes': player.hasTwoVotes,
-          you: session.sessionId && player.id && player.id === session.playerId,
+          you: player.connected && session.sessionId && player.id && player.id === session.playerId,
           'vote-yes':
             (!session.isSpectator ||
               session.isVoteWatchingAllowed ||
@@ -104,7 +104,10 @@
         icon="chair"
         v-if="player.id && session.sessionId"
         class="seat"
-        :class="{ highlight: session.isRolesDistributed }"
+        :class="{
+          highlight: session.isRolesDistributed,
+          disconnected: !player.connected
+        }"
       />
 
       <!-- Ghost vote icon -->
@@ -147,7 +150,7 @@
             @click="changePronouns"
             v-if="
               !session.isSpectator ||
-              (session.isSpectator && player.id === session.playerId)
+              (session.isSpectator && player.connected && player.id === session.playerId)
             "
           >
             <font-awesome-icon icon="venus-mars" />Change Pronouns
@@ -156,9 +159,7 @@
             @click="changeName"
             v-if="
               !session.isSpectator ||
-              (session.allowSelfNaming &&
-                session.isSpectator &&
-                player.id === session.playerId)
+              (session.allowSelfNaming && session.isSpectator && player.connected && player.id === session.playerId)
             "
           >
             <font-awesome-icon icon="user-edit" />Rename
@@ -203,7 +204,7 @@
             :class="{ disabled: player.id && player.id !== session.playerId }"
           >
             <font-awesome-icon icon="chair" />
-            <template v-if="!player.id"> Claim seat </template>
+            <template v-if="!player.id || (player.id === session.playerId && !player.connected)"> Claim seat </template>
             <template v-else-if="player.id === session.playerId">
               Vacate seat
             </template>
@@ -771,6 +772,10 @@ li.move:not(.from) .player .overlay svg.move {
   &.highlight {
     animation-iteration-count: 1;
     animation: redToWhite 1s normal forwards;
+  }
+
+  &.disconnected {
+    color: red;
   }
 }
 

--- a/src/components/TownSquare.vue
+++ b/src/components/TownSquare.vue
@@ -134,7 +134,8 @@ export default {
     },
     claimSeat(playerIndex) {
       if (!this.session.isSpectator) return;
-      if (this.session.playerId === this.players[playerIndex].id) {
+      const player = this.players[playerIndex];
+      if (this.session.playerId === player.id && player.connected) {
         this.$store.commit("session/claimSeat", -1);
       } else {
         this.$store.commit("session/claimSeat", playerIndex);

--- a/src/store/modules/players.js
+++ b/src/store/modules/players.js
@@ -1,6 +1,7 @@
 const NEWPLAYER = {
   name: "",
   id: "",
+  connected: false,
   role: {},
   reminders: [],
   isVoteless: false,


### PR DESCRIPTION
Added support for reserving seats for disconnected players, to prevent unknown actors from taking advantage of a disconnection to update pronouns or maliciously vote/abstain during nominations while the player is absent. This is a larger feature with a lot of changes that require testing. I believe the changes are complete but it's possible I have missed some cases, I am still testing locally.

Notable changes:
- Players that lose connection have their seat reserved, no other player can claim it until the Storyteller manually empties it.
- Players that actively vacate their seat or leave the session do not reserve their seat.
- Reserved seats display with a red chair icon to make it clear that a player has lost connection.

Feedback appreciated, whether it be to let me know I've missed something or you think there's a better implementation of this functionality or something else entirely.