### PR TITLE
Improve seat reservation behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Release Notes
 
+### Version 2.18.1
+- Fix players being able to vote while not connected to their seat
+- Hosting a new Session now clears all reserved seats
+- Added a ToolTip to the seat icon to clarify the reserved/connected state
+
+---
+
 ### Version 2.18.0
 - Players that lose connection to their active session have their seats reserved in case they reconnect
 - Reserved seats cannot be claimed by another player and have their chair icon display as red

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "townsquare",
-  "version": "2.17.1",
+  "version": "2.18.1",
   "description": "Blood on the Clocktower Town Square",
   "author": "Steffen Baumgart",
   "scripts": {

--- a/src/components/Player.vue
+++ b/src/components/Player.vue
@@ -108,6 +108,7 @@
           highlight: session.isRolesDistributed,
           disconnected: !player.connected
         }"
+        :title="setSeatTitle()"
       />
 
       <!-- Ghost vote icon -->
@@ -377,6 +378,20 @@ export default {
     claimSeat() {
       this.isMenuOpen = false;
       this.$emit("trigger", ["claimSeat"]);
+    },
+    setSeatTitle() {
+      if (this.player.connected) {
+        if (this.player.id === this.session.playerId) {
+          return "Your claimed seat";
+        }
+        return "Seat claimed by " + this.player.name;
+      }
+      else {
+        if (this.player.id === this.session.playerId) {
+          return "Your reserved seat. Click 'Claim seat' to reconnect";
+        }
+        return "Seat reserved for " + this.player.name;
+      }
     },
     /**
      * Allow the ST to override a locked vote.

--- a/src/components/Vote.vue
+++ b/src/components/Vote.vue
@@ -106,6 +106,7 @@
         </div>
       </template>
       <div v-else-if="!player">Please claim a seat to vote.</div>
+      <div v-else-if="!player.connected">Please reclaim your seat to vote.</div>
     </div>
     <transition name="blur">
       <div
@@ -169,6 +170,7 @@ export default {
     },
     canVote: function () {
       if (!this.player) return false;
+      if (!this.player.connected) return false;
       if (this.player.isVoteless && this.nominee.role.team !== "traveler")
         return false;
       const session = this.session;

--- a/src/store/socket.js
+++ b/src/store/socket.js
@@ -269,6 +269,21 @@ class LiveSession {
     this._store.commit("session/setPlayerCount", 0);
     this._store.commit("session/setPing", 0);
     this._isSpectator = this._store.state.session.isSpectator;
+    if (!this._isSpectator) {
+      // clear all claimed and reserved seats when hosting a new session
+      this._store.state.players.players.forEach((player) => {
+        this._store.commit("players/update", {
+          player: player,
+          property: "id",
+          value: "",
+        });
+        this._store.commit("players/update", {
+          player: player,
+          property: "connected",
+          value: false,
+        });
+      });
+    }
     this._open(channel);
   }
 
@@ -657,7 +672,7 @@ class LiveSession {
           delete this._pings[player];
         }
       }
-      // remove claimed seats from players that are no longer connected
+      // reserve previously claimed seats for players that are no longer connected
       this._store.state.players.players.forEach((player) => {
         if (player.connected && !this._players[player.id]) {
           this._store.commit("players/update", {


### PR DESCRIPTION
Added a couple of improvements to the reservation behaviour.

* Hosting a new session will immediately clear all claimed and reserved seats
* Added a ToolTip to the seat icon that clarifies the current state of the seat. There are 4 possible states:
  * Player views their own seat's ToolTip whilst connected
  * Player views their own seat's ToolTip whilst disconnected
  * Player views another player's seat's ToolTip whilst connected
  * Player views another player's seat's ToolTip whilst disconnected