### PR TITLE
Revert name & author text change and fix option still labelled "vote watching"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+### Version 2.20.1
+- Reverted change to hide name and author of script if a custom logo is being used
+- Renamed remaining options that were still labelled "vote watching"
+
 ### Version 2.20.0
 - Added opposing alignment functionality for both official and homebrew characters (with explicit permission from TPI)
 - Added menu option for changing a players' alignment - this functionality is only client side and will never be shown to players, even for travellers

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "townsquare",
-  "version": "2.19.1",
+  "version": "2.20.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "townsquare",
-      "version": "2.19.1",
+      "version": "2.20.0",
       "license": "GPL-3.0",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^1.2.32",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "townsquare",
-  "version": "2.20.0",
+  "version": "2.20.1",
   "description": "Blood on the Clocktower Town Square",
   "author": "Steffen Baumgart",
   "scripts": {

--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -153,19 +153,6 @@
             </li>
             <li
               v-if="!session.isSpectator"
-              @click="setTwoVotes"
-            >
-              Voting Twice
-              <em
-              ><font-awesome-icon
-                :icon="[
-                  'fas',
-                  session.isTwoVotesEnabled ? 'check-square' : 'square',
-                ]"
-              /></em>
-            </li>
-            <li
-              v-if="!session.isSpectator"
               @click="setVoteWatching"
             >
               Secret Vote
@@ -174,6 +161,19 @@
                 :icon="[
                   'fas',
                   !session.isVoteWatchingAllowed ? 'check-square' : 'square',
+                ]"
+              /></em>
+            </li>
+            <li
+              v-if="!session.isSpectator"
+              @click="setTwoVotes"
+            >
+              Voting Twice
+              <em
+              ><font-awesome-icon
+                :icon="[
+                  'fas',
+                  session.isTwoVotesEnabled ? 'check-square' : 'square',
                 ]"
               /></em>
             </li>

--- a/src/components/TownInfo.vue
+++ b/src/components/TownInfo.vue
@@ -13,7 +13,7 @@
     ></li>
     <li v-if="players.length - teams.traveller < 5">Please add more players!</li>
     <li>
-      <span class="meta" v-if="!edition.isOfficial && !(edition.logo && grimoire.isImageOptIn)">
+      <span class="meta" v-if="!edition.isOfficial">
         {{ edition.name }}
         {{ edition.author ? "by " + edition.author : "" }}
       </span>

--- a/src/components/modals/VoteHistoryModal.vue
+++ b/src/components/modals/VoteHistoryModal.vue
@@ -29,10 +29,10 @@
           <font-awesome-icon
             :icon="[
               'fas',
-              session.isVoteWatchingAllowed ? 'check-square' : 'square',
+              !session.isVoteWatchingAllowed ? 'check-square' : 'square',
             ]"
           />
-          Vote Watching
+          Secret Vote
         </div>
         <div class="option" @click="setTwoVotes">
           <font-awesome-icon


### PR DESCRIPTION
- Reverted change to hide name and author of script if a custom logo is being used, at least temporarily. It seems that majority of people preferred the functionality the way it was previously. If the official JSON schema ever implements something to make this aspect more customizable, this could be re-implemented.
- Renamed remaining options that were still labelled "vote watching"