### PR TITLE
Fix Fool & Bishop ability text and add missing Organ Grinder reminder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Release Notes
 
+### Version 2.20.2
+- Corrected Fool ability and reminder token texts to match the official app and physical game
+
 ### Version 2.20.1
 - Reverted change to hide name and author of script if a custom logo is being used
 - Renamed remaining options that were still labelled "vote watching"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Version 2.20.2
 - Corrected Fool & Bishop ability texts to match the official app and physical game
+- Added missing "About To Die" reminder for the Organ Grinder
 
 ### Version 2.20.1
 - Reverted change to hide name and author of script if a custom logo is being used

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Release Notes
 
 ### Version 2.20.2
-- Corrected Fool ability and reminder token texts to match the official app and physical game
+- Corrected Fool & Bishop ability texts to match the official app and physical game
 
 ### Version 2.20.1
 - Reverted change to hide name and author of script if a custom logo is being used

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "townsquare",
-  "version": "2.20.1",
+  "version": "2.20.2",
   "description": "Blood on the Clocktower Town Square",
   "author": "Steffen Baumgart",
   "scripts": {

--- a/src/roles.json
+++ b/src/roles.json
@@ -498,10 +498,10 @@
     "firstNightReminder": "",
     "otherNightReminder": "",
     "reminders": [
-      "No ability"
+      "No Ability"
     ],
     "setup": false,
-    "ability": "The first time you die, you don't."
+    "ability": "The 1st time you die, you don't."
   },
   {
     "id": "goon",

--- a/src/roles.json
+++ b/src/roles.json
@@ -729,7 +729,7 @@
       "Nominate Evil"
     ],
     "setup": false,
-    "ability": "Only the Storyteller can nominate. At least 1 opposite player must be nominated each day."
+    "ability": "Only the Storyteller can nominate. At least 1 opposing player must be nominated each day."
   },
   {
     "id": "clockmaker",

--- a/src/roles.json
+++ b/src/roles.json
@@ -1783,6 +1783,7 @@
     "firstNightReminder": "Wake the Organ Grinder. If they give the 'yes' head signal, mark them Drunk. If they give the 'no' head signal, remove the Drunk reminder.",
     "otherNightReminder": "Wake the Organ Grinder. If they give the 'yes' head signal, mark them Drunk. If they give the 'no' head signal, remove the Drunk reminder.",
     "reminders": [
+      "About To Die",
       "Drunk"
     ],
     "setup": false,


### PR DESCRIPTION
- Corrected Fool & Bishop ability texts to match the official app and physical game
- Added missing "About To Die" reminder for the Organ Grinder