### PR TITLE
Correct various ability texts, hide Traveller alignment on townsquare, disable night shrouding, and add support for recent JSON schema changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Release Notes
 
+### Version 2.20.3
+- Corrected Atheist ability text to match the official app and upcoming physical tokens
+
 ### Version 2.20.2
 - Corrected Fool & Bishop ability texts to match the official app and physical game
 - Added missing "About To Die" reminder for the Organ Grinder

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Release Notes
 
 ### Version 2.20.3
-- Corrected Atheist ability text to match the official app and upcoming physical tokens
+- Corrected Atheist, Fearmonger, & Lord of Typhon ability texts to match the official app and upcoming physical tokens
+- Corrected Beggar, Fibbin, Bone Collector, Pit-Hag, Scarlet Woman, & Voudon ability texts to match the official app and physical game
 
 ### Version 2.20.2
 - Corrected Fool & Bishop ability texts to match the official app and physical game

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Release Notes
 
 ### Version 2.20.3
-- Corrected Atheist, Fearmonger, & Lord of Typhon ability texts to match the official app and upcoming physical tokens
-- Corrected Beggar, Fibbin, Bone Collector, Pit-Hag, Scarlet Woman, & Voudon ability texts to match the official app and physical game
+- Corrected Atheist, Fearmonger, Lord of Typhon, Beggar, Fibbin, Bone Collector, Pit-Hag, Scarlet Woman, & Voudon ability texts to match the official app and existing/upcoming physical tokens
+- Changed Town Square view to hide the alignment of Travellers
+- Added the ability to hide a custom script's title and author following the recent change to the official [JSON Schema](https://github.com/ThePandemoniumInstitute/botc-release/blob/main/script-schema.json)
+- Added support for custom Bootlegger rules, following the recent change to the official [JSON Schema](https://github.com/ThePandemoniumInstitute/botc-release/blob/main/script-schema.json)
+- Disabled the ability to add death shrouds during the night phase to avoid accidental shrouding - players can still be publicly killed during the night by flipping the tokens with 'G'
+- Renamed "Remove All" characters to "Clear All" to disambiguate this menu option with "Remove All" players
 
 ### Version 2.20.2
 - Corrected Fool & Bishop ability texts to match the official app and physical game

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "townsquare",
-  "version": "2.20.0",
+  "version": "2.20.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "townsquare",
-      "version": "2.20.0",
+      "version": "2.20.3",
       "license": "GPL-3.0",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^1.2.32",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "townsquare",
-  "version": "2.20.2",
+  "version": "2.20.3",
   "description": "Blood on the Clocktower Town Square",
   "author": "Steffen Baumgart",
   "scripts": {

--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -217,7 +217,7 @@
             <em><font-awesome-icon icon="dragon" /></em>
           </li>
           <li @click="clearRoles" v-if="players.length">
-            Remove All
+            Clear All
             <em><font-awesome-icon icon="trash-alt" /></em>
           </li>
         </template>

--- a/src/components/Player.vue
+++ b/src/components/Player.vue
@@ -52,7 +52,7 @@
 
       <Token
         :role="player.role"
-        :alignmentIndex="player.alignmentIndex"
+        :alignmentIndex="player.role.team === 'traveller' && grimoire.isPublic ? 0 : player.alignmentIndex"
         @set-role="$emit('trigger', ['openRoleModal'])"
       />
 
@@ -489,7 +489,8 @@ export default {
       pointer-events: none;
     }
 
-    #townsquare.spectator & {
+    #townsquare.spectator &,
+    #app.night & {
       pointer-events: none;
     }
 

--- a/src/components/TownInfo.vue
+++ b/src/components/TownInfo.vue
@@ -13,7 +13,7 @@
     ></li>
     <li v-if="players.length - teams.traveller < 5">Please add more players!</li>
     <li>
-      <span class="meta" v-if="!edition.isOfficial">
+      <span class="meta" v-if="!(edition.isOfficial || edition.hideTitle)">
         {{ edition.name }}
         {{ edition.author ? "by " + edition.author : "" }}
       </span>

--- a/src/components/modals/ReferenceModal.vue
+++ b/src/components/modals/ReferenceModal.vue
@@ -16,6 +16,30 @@
       <font-awesome-icon icon="address-card" />
       {{ edition.name || "Custom Script" }}
     </h3>
+
+    <div class="team bootlegger" v-if="edition.bootlegger && edition.bootlegger.length">
+      <aside>
+        <h4>Rules</h4>
+      </aside>
+      <ul>
+        <li v-for="(rule, index) in edition.bootlegger" :key="index">
+          <span
+            class="icon"
+            :style="{
+              backgroundImage: `url(${
+                require('../../assets/icons/bootlegger.webp')
+              })`,
+            }"
+          ></span>
+          <div class="role">
+            <span class="ability">{{ rule }}</span>
+          </div>
+        </li>
+        <li></li>
+        <li></li>
+      </ul>
+    </div>
+
     <div
       v-for="(teamRoles, team) in rolesGrouped"
       :key="team"
@@ -221,6 +245,12 @@ h3 {
   }
   aside {
     background: linear-gradient(-90deg, $fabled, transparent);
+  }
+}
+
+.bootlegger {
+  aside {
+    background: linear-gradient(-90deg, #ffc01f, transparent);
   }
 }
 

--- a/src/customs.json
+++ b/src/customs.json
@@ -1,10 +1,10 @@
 {
-  "teensyville":[
+  "teensyville": [
     [
       {
-        "id":"_meta",
-        "author":"Steven Medway",
-        "name":"No Greater Joy"
+        "id": "_meta",
+        "author": "Steven Medway",
+        "name": "No Greater Joy"
       },
       "investigator",
       "clockmaker",
@@ -20,10 +20,11 @@
     ],
     [
       {
-        "id":"_meta",
-        "logo":"https://i.imgur.com/DUzjsL4.png",
-        "author":"Steven Medway",
-        "name":"Laissez un Faire"
+        "id": "_meta",
+        "logo": "https://i.imgur.com/DUzjsL4.png",
+        "hideTitle": true,
+        "author": "Steven Medway",
+        "name": "Laissez un Faire"
       },
       "balloonist",
       "savant",
@@ -38,12 +39,12 @@
       "leviathan"
     ]
   ],
-  "standard":[
+  "standard": [
     [
       {
-        "id":"_meta",
-        "author":"Emily",
-        "name":"Catfishing"
+        "id": "_meta",
+        "author": "Emily",
+        "name": "Catfishing"
       },
       "chef",
       "investigator",
@@ -73,9 +74,9 @@
     ],
     [
       {
-        "id":"_meta",
-        "author":"Lau",
-        "name":"Boozling"
+        "id": "_meta",
+        "author": "Lau",
+        "name": "Boozling"
       },
       "noble",
       "pixie",
@@ -105,10 +106,10 @@
     ],
     [
       {
-        "id":"_meta",
+        "id": "_meta",
         "logo": "https://i.imgur.com/OAs1fvK.png",
-        "author":"Viva La Sam",
-        "name":"Extension Cord"
+        "author": "Viva La Sam",
+        "name": "Extension Cord"
       },
       "investigator",
       "pixie",
@@ -143,9 +144,12 @@
     ],
     [
       {
-        "id":"_meta",
-        "author":"Theo",
-        "name":"Harold Holt's Revenge"
+        "id": "_meta",
+        "author": "Theo",
+        "name": "Harold Holt's Revenge",
+        "bootlegger": [
+          "All players always learn that the Leviathan is in play on day 1, even if the Leviathan is drunk."
+        ]
       },
       "investigator",
       "librarian",

--- a/src/fabled.json
+++ b/src/fabled.json
@@ -90,7 +90,7 @@
     "setup": false,
     "name": "Fibbin",
     "team": "fabled",
-    "ability": "Once per game, 1 good player might get false information."
+    "ability": "Once per game, 1 good player might get incorrect information."
   },
   {
     "id": "duchess",

--- a/src/roles.json
+++ b/src/roles.json
@@ -1493,7 +1493,7 @@
     "otherNightReminder": "",
     "reminders": [],
     "setup": true,
-    "ability": "The Storyteller can break the game rules & if executed, good wins, even if you are dead. [No evil characters]"
+    "ability": "The Storyteller can break the game rules, and if executed, good wins, even if you are dead. [No evil characters]"
   },
   {
     "id": "ogre",

--- a/src/roles.json
+++ b/src/roles.json
@@ -245,7 +245,7 @@
       "Is The Demon"
     ],
     "setup": false,
-    "ability": "If there are 5 or more players alive & the Demon dies, you become the Demon. (Travellers don't count)"
+    "ability": "If there are 5 or more players alive & the Demon dies, you become the Demon. (Travellers don't count.)"
   },
   {
     "id": "baron",
@@ -328,7 +328,7 @@
     "otherNightReminder": "",
     "reminders": [],
     "setup": false,
-    "ability": "You must use a vote token to vote. Dead players may choose to give you theirs. If so, you learn their alignment. You are sober & healthy."
+    "ability": "You must use a vote token to vote. If a dead player gives you theirs, you learn their alignment. You are sober & healthy."
   },
   {
     "id": "grandmother",
@@ -715,7 +715,7 @@
     "otherNightReminder": "",
     "reminders": [],
     "setup": false,
-    "ability": "Only you & the dead can vote. They don't need a vote token to do so. A 50% majority is not required."
+    "ability": "Only you & the dead can vote. They don't need a vote token to do so. A 50% majority isn't required."
   },
   {
     "id": "bishop",
@@ -984,7 +984,7 @@
     "otherNightReminder": "The Pit-Hag points to a player and a character on the sheet. If this character is not in play, wake that player and show them the 'You are' card and the relevant character token. If the character is in play, nothing happens.",
     "reminders": [],
     "setup": false,
-    "ability": "Each night*, choose a player & a character they become (if not-in-play). If a Demon is made, deaths tonight are arbitrary."
+    "ability": "Each night*, choose a player & a character they become (if not in play). If a Demon is made, deaths tonight are arbitrary."
   },
   {
     "id": "eviltwin",
@@ -1124,7 +1124,7 @@
       "Has Ability"
     ],
     "setup": false,
-    "ability": "Once per game, at night, choose a dead player: they regain their ability until dusk."
+    "ability": "Once per game, at night*, choose a dead player: they regain their ability until dusk."
   },
   {
     "id": "steward",
@@ -1657,7 +1657,7 @@
       "Fear"
     ],
     "setup": false,
-    "ability": "Each night, choose a player. If you nominate & execute them, their team loses. All players know if you choose a new player."
+    "ability": "Each night, choose a player: if you nominate & execute them, their team loses. All players know if you choose a new player."
   },
   {
     "id": "psychopath",
@@ -1677,7 +1677,10 @@
     "team": "minion",
     "firstNightReminder": "If the Wizard's wish requires actions at night, run these.",
     "otherNightReminder": "If the Wizard's wish requires actions at night, run these.",
-    "reminders": ["?","?"],
+    "reminders": [
+      "?",
+      "?"
+    ],
     "setup": false,
     "ability": "Once per game, choose to make a wish. If granted, it might have a price & leave a clue as to its nature."
   },
@@ -1896,7 +1899,7 @@
       "Dead"
     ],
     "setup": true,
-    "ability": "Each night*, choose a player: they die. [Evil characters are in a line. You are in the middle. +1 Minion. -? To +? Outsiders]"
+    "ability": "Each night*, choose a player: they die. [Evil characters are in a line. You are in the middle. +1 Minion. -? to +? Outsiders]"
   },
   {
     "id": "lleech",


### PR DESCRIPTION
- Corrected Atheist, Fearmonger, Lord of Typhon, Beggar, Fibbin, Bone Collector, Pit-Hag, Scarlet Woman, & Voudon ability texts to match the official app and existing/upcoming physical tokens
- Changed Town Square view to hide the alignment of Travellers
- Added the ability to hide a custom script's title and author following the recent change to the official JSON Schema
- Added support for custom Bootlegger rules, following the recent change to the official JSON Schema
- Disabled the ability to add death shrouds during the night phase to avoid accidental shrouding - players can still be publicly killed during the night by flipping the tokens with 'G'
- Renamed "Remove All" characters to "Clear All" to disambiguate this menu option with "Remove All" players

Resolves #37, resolves #42, resolves #43