### PR TITLE
voting time changes to be 0.1s increments for parity with Official App.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Release Notes
 
+### Version 2.20.6
+- Added more vote time per player intervals (0.5s --> 0.1s)
+
 ### Version 2.20.5
 - Added Wraith and Cacklejack
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "townsquare",
-  "version": "2.20.7",
+  "version": "2.20.8",
   "description": "Blood on the Clocktower Town Square",
   "author": "Steffen Baumgart",
   "scripts": {

--- a/src/components/Vote.vue
+++ b/src/components/Vote.vue
@@ -31,12 +31,12 @@
         >
           Time per player:
           <font-awesome-icon
-            @mousedown.prevent="setVotingSpeed(-500)"
+            @mousedown.prevent="setVotingSpeed(-100)"
             icon="minus-circle"
           />
           {{ session.votingSpeed / 1000 }}s
           <font-awesome-icon
-            @mousedown.prevent="setVotingSpeed(500)"
+            @mousedown.prevent="setVotingSpeed(100)"
             icon="plus-circle"
           />
         </div>
@@ -282,7 +282,7 @@ export default {
     },
     setVotingSpeed(diff) {
       const speed = Math.round(this.session.votingSpeed + diff);
-      if (speed > 0) {
+      if (speed >= 500 && speed <= 4000) {
         this.$store.commit("session/setVotingSpeed", speed);
       }
     },


### PR DESCRIPTION
Hello!

resolves #50 

For parity with the official app's increments (0.5, 0.6, 0.7, etc). The range has also been limited to be consistent with the app's (frankly insane) wide range. 

This feature is commonly requested amongst my Storyteller peers who still use this for Livevoice on BOTCU. I feel like it would be a great addition. 