### PR TITLE
Added ForceClearRoles and RevealRole options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Release Notes
 
 ### Version 2.21.3
+- Added button "Force Clear All Roles" in the "Hosting" tab for the ST, that clears All roles for the rest of players.
+- Added button in the player role modal for the ST to be able to reveal that character to all other players.
+
+### Version 2.21.3
 - Fixed roles received sound effect not muting when sound effects were muted
 
 ### Version 2.21.2

--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -176,6 +176,10 @@
                   ]"
               /></em>
             </li>
+            <li @click="forceClearRoles" v-if="!session.isSpectator">
+              Force Clear All Roles
+              <em><font-awesome-icon icon="trash-alt" /></em>
+            </li>
             <li @click="leaveSession">
               Leave Session
               <em>{{ session.sessionId }}</em>
@@ -358,6 +362,15 @@ export default {
         this.$store.commit("session/setSpectator", true);
         this.$store.commit("toggleGrimoire", false);
         this.$store.commit("session/setSessionId", sessionId);
+      }
+    },
+    forceClearRoles() {
+      if (
+        confirm(
+          "Are you sure you want to clear ALL PLAYERS' grimoires?",
+        )
+      ) {
+        this.$store.commit("session/forceClearRoles");
       }
     },
     leaveSession() {

--- a/src/components/Player.vue
+++ b/src/components/Player.vue
@@ -226,6 +226,10 @@
                 {{ isNominating ? "Cancel Nomination" : "Nomination" }}
               </li>
             </template>
+            <li @click="revealCharacter(player)">
+              <font-awesome-icon icon="theater-masks" />
+              Reveal Character
+            </li>
           </template>
           <li
             @click="claimSeat"
@@ -421,6 +425,21 @@ export default {
     nominatePlayer(player) {
       this.isMenuOpen = false;
       this.$emit("trigger", ["nominatePlayer", player]);
+    },
+    revealCharacter(player) {
+      this.isMenuOpen = false;
+      console.log(player.reminders);
+      const popup = "Do you want to reveal this role to ALL players?";
+      if (confirm(popup)) {
+        this.$store.state.players.players.find((pl, index) => {
+          if (pl.id == player.id && pl.name == player.name) {
+            this.$store.commit("session/revealRole", {
+              player: player,
+              index: index,
+            });
+          }
+        });
+      }
     },
     cancel() {
       this.$emit("trigger", ["cancel"]);

--- a/src/components/Vote.vue
+++ b/src/components/Vote.vue
@@ -231,19 +231,36 @@ export default {
       }, 4000);
     },
     start() {
-      this.$store.commit("session/lockVote", 1);
-      this.$store.commit("session/setVoteInProgress", true);
-      clearInterval(this.voteTimer);
-      if (this.session.isVoteWatchingAllowed) {
-        this.voteTimer = setInterval(() => {
-          this.$store.commit("session/lockVote");
-          if (this.session.lockedVote > this.players.length) {
-            clearInterval(this.voteTimer);
-            this.$store.commit("session/setVoteInProgress", false);
+      const plNotConnected = this.$store.state.players.players.some(
+        (res) => !res.id || res.id === "",
+      );
+      let exec = true;
+      if (plNotConnected) {
+        let popup = "Some players are not seated: \n";
+        this.$store.state.players.players.find((res) => {
+          if (!res.id || res.id === "") {
+            console.log(popup);
+            popup += res.name + ", ";
           }
-        }, this.session.votingSpeed);
-      } else {
-        this.$store.commit("session/lockVote", this.players.length + 1);
+          return false;
+        });
+        exec = confirm(popup);
+      }
+      if (exec) {
+        this.$store.commit("session/lockVote", 1);
+        this.$store.commit("session/setVoteInProgress", true);
+        clearInterval(this.voteTimer);
+        if (this.session.isVoteWatchingAllowed) {
+          this.voteTimer = setInterval(() => {
+            this.$store.commit("session/lockVote");
+            if (this.session.lockedVote > this.players.length) {
+              clearInterval(this.voteTimer);
+              this.$store.commit("session/setVoteInProgress", false);
+            }
+          }, this.session.votingSpeed);
+        } else {
+          this.$store.commit("session/lockVote", this.players.length + 1);
+        }
       }
     },
     pause() {

--- a/src/store/socket.js
+++ b/src/store/socket.js
@@ -221,6 +221,18 @@ class LiveSession {
       case "name":
         this._updatePlayerName(params);
         break;
+      case "reveal":
+        this._store.commit("players/update", {
+          player: this._store.state.players.players[params.index],
+          property: "role",
+          value: params.player.role,
+        }); 
+        break;
+      case "forceClearRoles":
+        if (this._isSpectator) {
+          this._store.dispatch("players/clearRoles");
+        }
+        break;
     }
   }
 
@@ -849,6 +861,22 @@ class LiveSession {
   }
 
   /**
+   * Reveal a role to all players.
+   * @param payload player to reveal { player, index }
+   */
+  revealRole(payload) {
+    if (this._isSpectator) return;
+    if (payload.player.role) {
+      this._send("reveal", payload);
+    }
+  }
+
+  forceClearRoles() {
+    if (this._isSpectator) return;
+    this._send("forceClearRoles");
+  }
+
+  /**
    * A player nomination. ST only
    * This also syncs the voting speed to the players.
    * Payload can be an object with {nomination} property or just the nomination itself, or undefined.
@@ -1083,6 +1111,9 @@ export default (store) => {
           session.distributeRoles();
         }
         break;
+      case "session/revealRole":
+        session.revealRole(payload);
+        break;
       case "session/nomination":
       case "session/setNomination":
         session.nomination(payload);
@@ -1110,6 +1141,9 @@ export default (store) => {
         break;
       case "session/setVoteWatchingAllowed":
         session.setVoteWatchingAllowed();
+        break;
+      case "session/forceClearRoles":
+        session.forceClearRoles();
         break;
       case "toggleNight":
         session.setIsNight();


### PR DESCRIPTION
Added ForceClearRoles as a button for the ST to remotely clear all players boards (excepts themself's).
Added RevealCharacter as a button in the player's modal for the ST to "reveal" that character to everyone board.

Both of them are intended to use as a way for the ST to resume/explain the game after its over.
Since both options are very sensitive, they have a confirmation popup before they are executed.