### PR TITLE
Removed check for Gardener in ShowSendCharacters

### DIFF
--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -138,7 +138,7 @@
               @click="distributeRoles"
             >
               Send Characters
-              <em><font-awesome-icon icon="seedling" /></em>
+              <em><font-awesome-icon icon="theater-masks" /></em>
             </li>
             <li
               v-if="session.voteHistory.length || !session.isSpectator"
@@ -291,7 +291,6 @@ export default {
   computed: {
     showSendCharacters: function () {
       return (
-        this.npcs.some((npc) => npc.id === "gardener") &&
         !this.npcs.some((npc) => npc.id === "tor")
       );
     },


### PR DESCRIPTION
Fixes #65

Removed check for Gardener in NPCs to re-enable "Send Characters" button for non-gardener games. Also modified the icon back to `theater-masks` due to the gardener check being removed, to sync back up with bra1n's styling.